### PR TITLE
Remove security/welcome page link from menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,6 @@ nav:
   - Generic:
     - "Using *.d folders": generic/dotdfolders.md
   - Security:
-    - Welcome to security: security/welcome.md
     - Certificate management: security/certificate-management.md
   - Operational Model:
     - "What is an operational model": operational-model/intro.md


### PR DESCRIPTION
The welcome link was removed but I forgot to remove the link from the menu. This fixes that.