### PR TITLE
Add to Certificates Section

### DIFF
--- a/docs/security/certificate-management.md
+++ b/docs/security/certificate-management.md
@@ -1,22 +1,24 @@
-# Basic certificate management
+# Basic CA certificate management
 
 Have you ever had to create custom java trust store or been greeted by an error message like `x509: certificate signed by unknown authority`? 
 Then this is section is for you.
 
 ## Background
 
-Many times enterprises may choose to have an internal PKI and Certificate Authority not trusted by anyone outside the organization.
+Many times enterprises may choose to have an internal PKI and Certificate Authority (CA) not trusted by anyone outside the organization.
 The drawback of this is that the CA's certificate needs to be distributed on all devices that need to trust the corporate CA.
 
 In the past this has meant that developers have been maintaining custom trust stores for their application runtime. Most commonly seen with Java.
 
 As most runtimes now use the operating systems trust store by default, adding the CA trust to the system trust instead removes the need for the application developer to bring along their own trust store and maintaining it separately when this instead can be part of the corporate Standard Operating Environment (SOE).
 
-## Recommended practice
+## Good practice
 
-As these certificates usually does not change very frequently the recommended practice on how to distribute these certificates is by packaging them up as an RPM and install them as part of the SOE.
+As these CA certificates usually do not change very frequently the recommended practice on how to distribute these certificates is by packaging them up as an RPM and install them as part of the SOE. 
+An alternative approach is to utilize a Configuration Management Tool, like Ansible. This also allows to update CA certificates in situations, where the connection to the repository server is via HTTPS, the certificates of the same CA are used, and the process is unstable, so the CA validity may break the rpm based process.
 
 ## References
 
 Additional details about the RHEL system trust store and how to add additional certificates to it is available in the
-[product documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/securing_networks/using-shared-system-certificates_securing-networks).
+[RHEL9 documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/securing_networks/using-shared-system-certificates_securing-networks).
+[RHEL10 documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/securing_networks/using-shared-system-certificates)


### PR DESCRIPTION
There might be an argument against the rpm based approach and utilizing ansible, depending on if you already build rpm or not and if you already use ansible or not.

but some nitpicky changes needed to be done to ensure it is clear, that CA certificates are meant throughout the text, as certificates are becoming more and more shortlived. 